### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## 📋 Descripción
+<!-- Describe los cambios realizados -->
+
+## 🎯 Tipo de cambio
+- [ ] 🚀 Feature (nueva funcionalidad)
+- [ ] 🐛 Bugfix (corrección de bug)
+- [ ] 🔥 Hotfix (corrección urgente)
+- [ ] ♻️ Refactor (mejora de código)
+- [ ] 📝 Docs (documentación)
+
+## 🧪 ¿Cómo se ha probado?
+<!-- Describe cómo probaste los cambios -->
+
+## ✅ Checklist
+- [ ] El código compila sin errores
+- [ ] Los tests pasan localmente
+- [ ] Agregué tests para los cambios
+- [ ] Actualicé la documentación si es necesario
+- [ ] El código sigue las convenciones del proyecto
+- [ ] Revisé que no haya console.logs ni TODOs
+
+## 📸 Screenshots (si aplica)
+<!-- Agrega capturas de pantalla si hay cambios visuales -->
+
+## 🔗 Issues relacionados
+Closes #(issue)


### PR DESCRIPTION
## 📋 Descripción
Agrega un template para Pull Requests que se mostrará automáticamente cada vez que alguien cree un PR. Esto estandariza la documentación de cambios y mejora la calidad de las revisiones de código.

## 🎯 Tipo de cambio
- [ ] 🚀 Feature (nueva funcionalidad)
- [ ] 🐛 Bugfix (corrección de bug)
- [ ] 🔥 Hotfix (corrección urgente)
- [ ] ♻️ Refactor (mejora de código)
- [x] 📝 Docs (documentación)

## 🧪 ¿Cómo se ha probado?
- Creación de este PR que automáticamente carga el template
- Verificación de que el archivo está en `.github/pull_request_template.md`

## ✅ Checklist
- [x] El código compila sin errores
- [x] Los tests pasan localmente
- [ ] Agregué tests para los cambios (N/A - solo documentación)
- [x] Actualicé la documentación si es necesario
- [x] El código sigue las convenciones del proyecto
- [x] Revisé que no haya console.logs ni TODOs

## 📸 Screenshots (si aplica)
N/A - Cambio en documentación

## 🔗 Issues relacionados
N/A